### PR TITLE
Added systems to speed up Demo's SOP

### DIFF
--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -62,6 +62,38 @@ if (isServer) then {
 };
 
 if (!hasInterface) exitWith {};
+["ace_explosives_place", 
+{
+	params ["_explosive", "_dir", "_pitch", "_unit"];
+	if (_explosive isKindOf "HX_AT_Mine_Ammo") then{
+        _object = attachedTo _explosive;
+        if (isNull _object) then {
+            _startPosASL = getPosASL _explosive vectorAdd (vectorup _explosive vectorMultiply 0.1);
+            _cameraDir =vectorUp _explosive vectorMultiply -1;
+            _endPosASL = _startPosASL vectorAdd (_cameraDir vectorMultiply 2.5);
+            _intersections = lineIntersectsSurfaces [_startPosASL, _endPosASL, _explosive, objNull, true, 1, "GEOM", "FIRE"];
+            (_intersections select 0) params ["_touchingPoint", "_surfaceNormal", "", "_object"];
+            if (_surfaceNormal vectorDotProduct  (_endPosASL vectorDiff _startPosASL) > 0) then {
+                _surfaceNormal = _surfaceNormal vectorMultiply -1;
+            };
+            private _v1 = vectorNormalized (_surfaceNormal vectorMultiply -1);
+            private _v2 = [];
+            private _v3 = [];
+            private _vectorDirAndUp = if (abs (_v1 select 2) < 0.94) then {
+                _v3 = _v1 vectorCrossProduct [0, 0, 1];
+                _v2 = _v3 vectorCrossProduct _v1;
+                [_v1, _v2]
+            } else {
+                _v2 = vectorNormalized (_v1 vectorCrossProduct (_endPosASL vectorDiff _startPosASL));
+                _v3 = _v1 vectorCrossProduct [0, 0, 1];
+                [_v1, [1,0,0]];
+            };
+            private _posTag = (getPosASL _explosive) vectorAdd (_v1 vectorMultiply -0.01);  
+            [_touchingPoint vectorAdd (_surfaceNormal vectorMultiply 0.01), _vectorDirAndUp, "z\ace\addons\tagging\UI\tags\red\circle.paa"] call ace_tagging_fnc_createTag;
+        };
+    };
+
+}] call CBA_fnc_addEventHandler;
 
 #include "initKeybinds.inc.sqf"
 

--- a/addons/explosives/functions/fnc_addClacker.sqf
+++ b/addons/explosives/functions/fnc_addClacker.sqf
@@ -44,6 +44,52 @@ _clacker pushBack [_explosive, getNumber(_config >> "FuseTime"), format [localiz
 
 _unit setVariable [QGVAR(Clackers), _clacker, true];
 
+//White-listed explosives
+Aux212_DemoCharges = [
+    ["Aux212_X3_Thermal_Disruptor_Ammo", "X3" , "10m"],
+    ["Aux212_X10_Thermal_Disruptor_Ammo","X10" , "30m"],
+    ["Aux212_7PrG_Proton_Charge_Ammo","Proton Charge", "10m"], 
+    ["JLTS_explosive_emp_10_Ammo", "EMP MK2", "10m"],
+    ["JLTS_explosive_emp_50_ammo", "EMP MK5", "50m"]
+    ];
+
+{
+    _ExType = Typeof _explosive;
+    if (toLower TypeOf _explosive isEqualTo toLower (_x select 0)) then 
+    {
+        //Create tag
+        _object = attachedTo _explosive;
+        if (isNull _object) then {
+            _startPosASL = getPosASL _explosive vectorAdd (vectorup _explosive vectorMultiply 0.1);
+            _cameraDir =vectorUp _explosive vectorMultiply -1;
+            _endPosASL = _startPosASL vectorAdd (_cameraDir vectorMultiply 2.5);
+            _intersections = lineIntersectsSurfaces [_startPosASL, _endPosASL, _explosive, objNull, true, 1, "GEOM", "FIRE"];
+            (_intersections select 0) params ["_touchingPoint", "_surfaceNormal", "", "_object"];
+            if (_surfaceNormal vectorDotProduct  (_endPosASL vectorDiff _startPosASL) > 0) then {
+                _surfaceNormal = _surfaceNormal vectorMultiply -1;
+            };
+            private _v1 = vectorNormalized (_surfaceNormal vectorMultiply -1);
+            private _v2 = [];
+            private _v3 = [];
+            private _vectorDirAndUp = if (abs (_v1 select 2) < 0.94) then {
+                _v3 = _v1 vectorCrossProduct [0, 0, 1];
+                _v2 = _v3 vectorCrossProduct _v1;
+                [_v1, _v2]
+            } else {
+                _v2 = vectorNormalized (_v1 vectorCrossProduct (_endPosASL vectorDiff _startPosASL));
+                _v3 = _v1 vectorCrossProduct [0, 0, 1];
+                [_v1, [1,0,0]];
+            };
+            private _posTag = (getPosASL _explosive) vectorAdd (_v1 vectorMultiply -0.01);  
+            [_touchingPoint vectorAdd (_surfaceNormal vectorMultiply 0.01), _vectorDirAndUp, "z\ace\addons\tagging\UI\tags\red\circle.paa"] call ace_tagging_fnc_createTag;
+        };
+        _markerID = format["_USER_DEFINED %1", random 1000000];
+        _marker = createMarker [_markerID, position _explosive, 1, _unit];
+        _marker setMarkerType "jmm_g_dot";
+        _marker setMarkerColor "ColorCIS";
+        _marker setMarkerText format["%1 %2 %3", _x select 1, _x select 2, format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]];
+    };
+}forEach Aux212_DemoCharges;
 //display clacker code message:
 [format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]] call EFUNC(common,displayTextStructured);
 

--- a/addons/explosives/functions/fnc_addClacker.sqf
+++ b/addons/explosives/functions/fnc_addClacker.sqf
@@ -45,13 +45,7 @@ _clacker pushBack [_explosive, getNumber(_config >> "FuseTime"), format [localiz
 _unit setVariable [QGVAR(Clackers), _clacker, true];
 
 //White-listed explosives
-Aux212_DemoCharges = [
-    ["Aux212_X3_Thermal_Disruptor_Ammo", "X3" , "10m"],
-    ["Aux212_X10_Thermal_Disruptor_Ammo","X10" , "30m"],
-    ["Aux212_7PrG_Proton_Charge_Ammo","Proton Charge", "10m"], 
-    ["JLTS_explosive_emp_10_Ammo", "EMP MK2", "10m"],
-    ["JLTS_explosive_emp_50_ammo", "EMP MK5", "50m"]
-    ];
+ _parseArray = parseSimpleArray Aux212_DemoCharges;
 
 {
     _ExType = Typeof _explosive;
@@ -89,7 +83,7 @@ Aux212_DemoCharges = [
         _marker setMarkerColor "ColorCIS";
         _marker setMarkerText format["%1 %2 %3", _x select 1, _x select 2, format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]];
     };
-}forEach Aux212_DemoCharges;
+}forEach _parseArray;
 //display clacker code message:
 [format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]] call EFUNC(common,displayTextStructured);
 

--- a/addons/explosives/initSettings.inc.sqf
+++ b/addons/explosives/initSettings.inc.sqf
@@ -53,3 +53,12 @@ private _categoryStr = format ["ACE %1", LLSTRING(Menu)];
     [_categoryStr, LLSTRING(ExplosiveTimer)],
     [0, 5999, TIMER_VALUE_DEFAULT]
 ] call CBA_fnc_addSetting;
+
+[
+    "Aux212_DemoCharges",
+    "EDITBOX",
+    ["Explosive Whitelist", "This is an array of array's to the system , to insert new explosive follow the pattern \n [['EXPLOSIVE_AMMO_CLASS', 'NAME', 'SAFE_DISTANCE']] \n don't forget that it's a group of array's inside an array"],
+    ["Aux212", "Demo SOP Automation"],
+    "[ ['Aux212_X3_Thermal_Disruptor_Ammo', 'X3' , '10m'],['Aux212_X10_Thermal_Disruptor_Ammo','X10' , '30m'],['Aux212_7PrG_Proton_Charge_Ammo','Proton Charge', '10m'], ['JLTS_explosive_emp_10_Ammo', 'EMP MK2', '10m'],['JLTS_explosive_emp_50_ammo', 'EMP MK5', '50m'] ]",
+    1
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
Scripts added directly to ace explosive `postinit` and `addClacker` function, when the user add the explosive to a clacker it will go through a Whitelist in the global variable `Aux212_DemoCharges` and check for each of the array's inside the global variable array and cross-check their index 0 to see if the explosive being added is in the list, if it is then the script will create a circle tag around the explosive using the `ace_tagging_fnc_createTag` function and add a map marker with the Name of the explosive `index 1` the distance `index 2` and the explosive code which is already on the  `addClacker` function. 

Exception for AT mines that runs in the `postinit` it will have the `createTag` function ran when activated (no map marker) as per request of Joker (current Demo lead)

Requires testing

Known issues: when you add an explosive to the clacker that is not up-right the circle tag will be created horizontally even tho it is on a slope